### PR TITLE
Add kryo serializer for Logger class

### DIFF
--- a/distributed/src/main/scala/org/dbpedia/extraction/spark/serialize/KryoExtractionRegistrator.scala
+++ b/distributed/src/main/scala/org/dbpedia/extraction/spark/serialize/KryoExtractionRegistrator.scala
@@ -6,6 +6,7 @@ import scala.Console._
 import org.dbpedia.extraction.sources.WikiPage
 import org.dbpedia.extraction.wikiparser.{Namespace, WikiTitle}
 import org.dbpedia.extraction.util.Language
+import java.util.logging.Logger
 
 /**
  * It's best to register the classes that will be serialized/deserialized with Kryo.
@@ -19,5 +20,6 @@ class KryoExtractionRegistrator extends KryoRegistrator
     kryo.register(classOf[WikiTitle], new WikiTitleSerializer)
     kryo.register(classOf[Namespace])
     kryo.register(classOf[Language], new LanguageSerializer)
+    kryo.register(classOf[Logger], new LoggerSerializer)
   }
 }

--- a/distributed/src/main/scala/org/dbpedia/extraction/spark/serialize/LoggerSerializer.scala
+++ b/distributed/src/main/scala/org/dbpedia/extraction/spark/serialize/LoggerSerializer.scala
@@ -1,0 +1,23 @@
+package org.dbpedia.extraction.spark.serialize
+
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
+import org.dbpedia.extraction.util.Language
+import java.util.logging.Logger
+
+/**
+ * Kryo serializer for org.dbpedia.extraction.util.Language
+ */
+class LoggerSerializer extends Serializer[Logger]
+{
+  override def write(kryo: Kryo, output: Output, logger: Logger)
+  {
+    output.writeString(logger.getName)
+  }
+
+  override def read(kryo: Kryo, input: Input, loggerClass: Class[Logger]): Logger =
+  {
+    val className = input.readString()
+    Logger.getLogger(className)
+  }
+}


### PR DESCRIPTION
This needs a quick merge. This solves a part of issue #9 too. java.util.logging.Logger classes are not easily serializable, and they're abundant in the Extractors/DataParsers on extraction-framework. So I added a custom kryo serializer for Loggers.
