### PR TITLE
Extractors will run!!

### DIFF
--- a/distributed/src/main/scala/org/dbpedia/extraction/dump/extract/DistDumpExtractionContext.scala
+++ b/distributed/src/main/scala/org/dbpedia/extraction/dump/extract/DistDumpExtractionContext.scala
@@ -1,0 +1,31 @@
+package org.dbpedia.extraction.dump.extract
+
+import org.dbpedia.extraction.util._
+import org.dbpedia.extraction.mappings._
+import org.dbpedia.extraction.sources._
+import org.dbpedia.extraction.ontology.Ontology
+import org.apache.spark.broadcast.Broadcast
+
+/**
+ * Wrapper for DumpExtractionContext to be used with Spark.
+ *
+ * Delegates all methods to a DumpExtractionContext broadcast variable.
+ */
+class DistDumpExtractionContext(contextBroadcast: Broadcast[_ <: DumpExtractionContext]) extends DumpExtractionContext
+{
+  override def ontology: Ontology = contextBroadcast.value.ontology
+
+  override def commonsSource: Source = contextBroadcast.value.commonsSource
+
+  override def language: Language = contextBroadcast.value.language
+
+  override def mappingPageSource: Traversable[WikiPage] = contextBroadcast.value.mappingPageSource
+
+  override def mappings: Mappings = contextBroadcast.value.mappings
+
+  override def articlesSource: Source = contextBroadcast.value.articlesSource
+
+  override def redirects: Redirects = contextBroadcast.value.redirects
+
+  override def disambiguations: Disambiguations = contextBroadcast.value.disambiguations
+}


### PR DESCRIPTION
1. Wrote a wrapper for `DumpExtractionContext` that delegates everything to a Spark `Broadcast[DumpExtractionContext]` variable. Fixes #13 
2. Took Spark/RDD stuff out of the `DumpExtractionContext` implementation. No problems anymore. All extractors work. Fixes #9 . Of course, ignoring `InfoboxExtractor` for now.

Note: The pull request is to the **nildev** branch. Let me know what you think and I'll merge this into nildev.
