### PR TITLE
Convert all File stuff to Path; add fallback to Config from DistConfig when required

### DIFF
--- a/distributed/src/test/scala/org/dbpedia/extraction/mappings/DistRedirectsTest.scala
+++ b/distributed/src/test/scala/org/dbpedia/extraction/mappings/DistRedirectsTest.scala
@@ -43,7 +43,8 @@ class DistRedirectsTest extends FunSuite
     val lang = config.extractorClasses.iterator.next()._1
 
     val localFinder = new Finder[File](config.dumpDir, lang, config.wikiName)
-    val distFinder = new Finder[Path](distConfig.dumpDir, lang, config.wikiName)
+    val distDumpDir = distConfig.dumpDir.getOrElse(new Path(config.dumpDir.getAbsolutePath))
+    val distFinder = new Finder[Path](distDumpDir, lang, config.wikiName)
     val date = latestDate(config, localFinder)
 
     // Get the readers for the test dump files


### PR DESCRIPTION
This was done to convert all remaining `File`-specific stuff to using `Path`. That is necessary because we have to support Hadoop file systems (HDFS etc.) equally well - already discussed.

As for this particular change, I personally feel this is getting pretty ugly because the client code is having to juggle between DistConfig and Config when it comes to dealing with `mappingsDir`, 'ontologyFile`and`dumpDir`. But this is supposed to be handled behind-the-scenes by the config object.

I propose to reject this PR and combine Config and DistConfig into one single DistConfig. I'll make a new PR. Here's how DistConfig will look like:

``` scala
/**
 * Class for distributed configuration
 */
class DistConfig(configProps: Properties, config: Config)
{
    // add all Spark and Hadoop-specific stuff

   // dumpDir, mappingsDir, ontologyFile => do the fallback to config logic here and delegate to config accordingly.

   // for the rest of the config.* methods, simply delegate. Act as wrapper.

}
```
