### PR TITLE
Make the directory/file vals lazy so that they don't throw initializatio...

### DIFF
--- a/distributed/src/main/scala/org/dbpedia/extraction/dump/extract/DistConfig.scala
+++ b/distributed/src/main/scala/org/dbpedia/extraction/dump/extract/DistConfig.scala
@@ -187,9 +187,9 @@ class DistConfig(distConfigProps: Properties, extractionConfigProps: Properties,
    */
   private class ExtractionConfig extends Config(extractionConfigProps)
   {
-    override val dumpDir: File = null
-    override val ontologyFile: File = null
-    override val mappingsDir: File = null
+    override lazy val dumpDir: File = null
+    override lazy val ontologyFile: File = null
+    override lazy val mappingsDir: File = null
   }
 
 }


### PR DESCRIPTION
These need to be lazy or else things like if (! dir.exists) throw error("dir "+dir+" does not exist") or File initialization errors in `Config` can mess with the initialization of `DistConfig` (which prevents distributed extraction from starting).

This mainly occurs if a path like hdfs:///somepath/somefile is given to base-dir in spark-config.properties, and the base-dir in the general config.properties is omitted, or set to hdfs:///somepath/somefile.

The PR for the Config side of things is at https://github.com/dbpedia/extraction-framework/pull/252
