### PR TITLE
Remove DistConfig.sparkNumSlices - it's not used anymore.

### DIFF
--- a/distributed/src/main/scala/org/dbpedia/extraction/dump/extract/DistConfig.scala
+++ b/distributed/src/main/scala/org/dbpedia/extraction/dump/extract/DistConfig.scala
@@ -31,9 +31,6 @@ class DistConfig(distConfigProps: Properties, extractionConfigProps: Properties,
   /** By default assume master is runnning locally; use 4 cores */
   val sparkMaster = distConfigProps.getProperty("spark-master", "local[4]")
 
-  /** Number of splits the initial RDD will be broken to - configure according to your cluster. Maybe total number of cores? */
-  val sparkNumSlices = distConfigProps.getProperty("spark-num-slices", "4").toInt
-
   /** Shows up on Spark Web UI */
   val sparkAppName = distConfigProps.getProperty("spark-appname", "dbpedia-distributed-extraction-framework")
 

--- a/distributed/src/test/scala/org/dbpedia/extraction/mappings/DistRedirectsTest.scala
+++ b/distributed/src/test/scala/org/dbpedia/extraction/mappings/DistRedirectsTest.scala
@@ -60,7 +60,7 @@ class DistRedirectsTest extends FunSuite
     val sc = SparkUtils.getSparkContext(distConfig)
     // Generate RDD from the article source for DistRedirects to load from in parallel
     // Naively calls toArray on Seq, only for testing
-    val rdd = sc.parallelize(articleSource.toSeq, distConfig.sparkNumSlices)
+    val rdd = sc.parallelize(articleSource.toSeq, 8)
     (distConfig, articleSource, rdd, lang, date, distFinder)
   } catch{ case ex:Exception => ex.printStackTrace(); (null, null,null, null,null, null)}
 


### PR DESCRIPTION
The new InputFormat does the splitting. Hardcoded no. of slices for sc.parallelize in DistRedirectsTest to 8.
