### PR TITLE
Fix gce ulimits + increasing nmon logging period

### DIFF
--- a/gce/spark_gce.py
+++ b/gce/spark_gce.py
@@ -406,7 +406,7 @@ def setup_spark(master_nodes,slave_nodes):
 
     setup_maven(master_nodes)
     
-    #if nmon_log_dir != "": setup_nmon(master_nodes,slave_nodes)
+    if nmon_log_dir != "": setup_nmon(master_nodes,slave_nodes)
     
     ssh_command(master,"cd engine;wget http://apache.mesi.com.ar/spark/spark-0.9.1/spark-0.9.1-bin-hadoop2.tgz")
     ssh_command(master,"cd engine;wget https://s3.amazonaws.com/sigmoidanalytics-builds/spark/0.9.1/gce/scala.tgz")
@@ -456,7 +456,7 @@ def setup_spark(master_nodes,slave_nodes):
 def setup_nmon(master_nodes,slave_nodes):
     for host in slave_nodes + master_nodes:
         print "[ Setting up nmon on %s ]" % host
-        ssh_command(host, "cd engine;mkdir nmon;cd nmon;wget -O nmon http://sourceforge.net/projects/nmon/files/nmon_x86_64_centos6;chmod a+x nmon;./nmon -s10 -f")
+        ssh_command(host, "cd engine;mkdir nmon;cd nmon;wget -O nmon http://sourceforge.net/projects/nmon/files/nmon_x86_64_centos6;chmod a+x nmon;./nmon -s10 -c10000000 -f")
 
 def aggregate_nmon(master_nodes,slave_nodes):
     for host in slave_nodes + master_nodes:


### PR DESCRIPTION
This fixes the ulimits issue. Enwiki runs successfully over the same configuration as we discussed!

nmon logging was stopping after a short time because of nmon defaults. Now it shouldn't, at least not till 100 million seconds.

@sangv please check and merge?
